### PR TITLE
Add an extra config option for burners that are Kindled by default, as well as the necessary changes to support it.

### DIFF
--- a/src/main/java/zeh/createlowheated/common/Configuration.java
+++ b/src/main/java/zeh/createlowheated/common/Configuration.java
@@ -10,7 +10,7 @@ public class Configuration {
 
 	public static ForgeConfigSpec.IntValue FAN_MULTIPLIER;
 	
-	public static ForgeConfigSpec.IntValue HOT_BURNERS_MULTIPLIER;
+	public static ForgeConfigSpec.IntValue BASE_MULTIPLIER;
 	
 	public static ForgeConfigSpec.BooleanValue HOT_BURNERS;
 
@@ -20,13 +20,13 @@ public class Configuration {
 
 		COMMON_BUILDER.comment("#Charcoal Burner Requirements").push("charcoal_burner");
 		
-		HOT_BURNERS_MULTIPLIER = COMMON_BUILDER.comment("How much more a burner consumes when the hotBurners option is active. Does not affect burners empowered by fans, use fanMultiplier instead.")
-				.defineInRange("hotBurnersMultiplier", 2, 1, Integer.MAX_VALUE);
-		
 		HOT_BURNERS = COMMON_BUILDER.comment("When set to True, an active Charcoal Burner produces the same heat as a Kindled Blaze Burner and an empowered Charcoal Burner produces the same heat as a Seething Blaze Burner. Inactive state is unaffected.")
 				.define("hotBurners", false);
 		
-		FAN_MULTIPLIER = COMMON_BUILDER.comment("How much more a burner consumes when empowered by a maxed encased fan.")
+		BASE_MULTIPLIER = COMMON_BUILDER.comment("How much more fuel a non-empowered Charcoal Burner consumes. Use fanMultiplier for fan-empowered burners. Intended for use with the hotBurners option, the default value of 1 is recommended otherwise.")
+				.defineInRange("baseMultiplier", 1, 1, Integer.MAX_VALUE);
+		
+		FAN_MULTIPLIER = COMMON_BUILDER.comment("How much more fuel a Charcoal Burner consumes when empowered by a maxed encased fan.")
 				.defineInRange("fanMultiplier", 100, 1, Integer.MAX_VALUE);
 
 		COMMON_BUILDER.pop();

--- a/src/main/java/zeh/createlowheated/common/Configuration.java
+++ b/src/main/java/zeh/createlowheated/common/Configuration.java
@@ -9,12 +9,23 @@ public class Configuration {
     public static ForgeConfigSpec COMMON_CONFIG;
 
 	public static ForgeConfigSpec.IntValue FAN_MULTIPLIER;
+	
+	public static ForgeConfigSpec.IntValue HOT_BURNERS_MULTIPLIER;
+	
+	public static ForgeConfigSpec.BooleanValue HOT_BURNERS;
 
     static {
 
 		ForgeConfigSpec.Builder COMMON_BUILDER = new ForgeConfigSpec.Builder();
 
 		COMMON_BUILDER.comment("#Charcoal Burner Requirements").push("charcoal_burner");
+		
+		HOT_BURNERS_MULTIPLIER = COMMON_BUILDER.comment("How much more a burner consumes when the hotBurners option is active. Does not affect burners empowered by fans, use fanMultiplier instead.")
+				.defineInRange("hotBurnersMultiplier", 2, 1, Integer.MAX_VALUE);
+		
+		HOT_BURNERS = COMMON_BUILDER.comment("When set to True, an active Charcoal Burner produces the same heat as a Kindled Blaze Burner and an empowered Charcoal Burner produces the same heat as a Seething Blaze Burner. Inactive state is unaffected.")
+				.define("hotBurners", false);
+		
 		FAN_MULTIPLIER = COMMON_BUILDER.comment("How much more a burner consumes when empowered by a maxed encased fan.")
 				.defineInRange("fanMultiplier", 100, 1, Integer.MAX_VALUE);
 

--- a/src/main/java/zeh/createlowheated/content/processing/charcoal/CharcoalBurnerBlockEntity.java
+++ b/src/main/java/zeh/createlowheated/content/processing/charcoal/CharcoalBurnerBlockEntity.java
@@ -32,16 +32,21 @@ public class CharcoalBurnerBlockEntity extends SmartBlockEntity {
     protected FuelType activeFuel;
     protected int remainingBurnTime;
     protected int fanMultiplier;
+    protected int baseMultiplier;
     protected boolean hotBurners;
-    protected int hotBurnersMultiplier;
+    protected HeatLevel activeHeatLevel;
+    protected HeatLevel empoweredHeatLevel;
+    
 
     public CharcoalBurnerBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
         activeFuel = FuelType.NONE;
         remainingBurnTime = 0;
         fanMultiplier = Configuration.FAN_MULTIPLIER.get();
+        baseMultiplier= Configuration.BASE_MULTIPLIER.get();
         hotBurners = Configuration.HOT_BURNERS.get();
-        hotBurnersMultiplier = Configuration.HOT_BURNERS_MULTIPLIER.get();
+        activeHeatLevel = hotBurners ? HeatLevel.KINDLED : HeatLevel.byIndex(5);
+        empoweredHeatLevel = hotBurners ? HeatLevel.SEETHING : HeatLevel.KINDLED;
     }
 
     public FuelType getActiveFuel() {
@@ -71,8 +76,7 @@ public class CharcoalBurnerBlockEntity extends SmartBlockEntity {
 
         if (remainingBurnTime > 0) {
             if (getEmpoweredFromBlock()) remainingBurnTime -= fanMultiplier;
-            else if (hotBurners) remainingBurnTime -= hotBurnersMultiplier;
-            else remainingBurnTime--;
+            else remainingBurnTime-=baseMultiplier;
         }
         if (remainingBurnTime < 0) remainingBurnTime = 0;
         if (activeFuel == FuelType.NORMAL) updateBlockState();
@@ -194,11 +198,7 @@ public class CharcoalBurnerBlockEntity extends SmartBlockEntity {
         if (!getLitFromBlock()) return level;
         switch (activeFuel) {
             case NORMAL:
-            	if (hotBurners) {
-            		level = getEmpoweredFromBlock() ? HeatLevel.SEETHING : HeatLevel.KINDLED;
-            	} else {
-            		level = getEmpoweredFromBlock() ? HeatLevel.KINDLED : HeatLevel.byIndex(5);
-            	}
+            	level = getEmpoweredFromBlock() ? empoweredHeatLevel : activeHeatLevel;
                 break;
             default:
             case NONE:

--- a/src/main/java/zeh/createlowheated/content/processing/charcoal/CharcoalBurnerBlockEntity.java
+++ b/src/main/java/zeh/createlowheated/content/processing/charcoal/CharcoalBurnerBlockEntity.java
@@ -32,12 +32,16 @@ public class CharcoalBurnerBlockEntity extends SmartBlockEntity {
     protected FuelType activeFuel;
     protected int remainingBurnTime;
     protected int fanMultiplier;
+    protected boolean hotBurners;
+    protected int hotBurnersMultiplier;
 
     public CharcoalBurnerBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
         activeFuel = FuelType.NONE;
         remainingBurnTime = 0;
         fanMultiplier = Configuration.FAN_MULTIPLIER.get();
+        hotBurners = Configuration.HOT_BURNERS.get();
+        hotBurnersMultiplier = Configuration.HOT_BURNERS_MULTIPLIER.get();
     }
 
     public FuelType getActiveFuel() {
@@ -67,6 +71,7 @@ public class CharcoalBurnerBlockEntity extends SmartBlockEntity {
 
         if (remainingBurnTime > 0) {
             if (getEmpoweredFromBlock()) remainingBurnTime -= fanMultiplier;
+            else if (hotBurners) remainingBurnTime -= hotBurnersMultiplier;
             else remainingBurnTime--;
         }
         if (remainingBurnTime < 0) remainingBurnTime = 0;
@@ -189,7 +194,11 @@ public class CharcoalBurnerBlockEntity extends SmartBlockEntity {
         if (!getLitFromBlock()) return level;
         switch (activeFuel) {
             case NORMAL:
-                level = getEmpoweredFromBlock() ? HeatLevel.KINDLED : HeatLevel.byIndex(5);
+            	if (hotBurners) {
+            		level = getEmpoweredFromBlock() ? HeatLevel.SEETHING : HeatLevel.KINDLED;
+            	} else {
+            		level = getEmpoweredFromBlock() ? HeatLevel.KINDLED : HeatLevel.byIndex(5);
+            	}
                 break;
             default:
             case NONE:

--- a/src/main/java/zeh/createlowheated/mixin/BoilerHeatersMixin.java
+++ b/src/main/java/zeh/createlowheated/mixin/BoilerHeatersMixin.java
@@ -30,6 +30,7 @@ public class BoilerHeatersMixin {
             HeatLevel value = state.getValue(CharcoalBurnerBlock.HEAT_LEVEL);
             if (value == HeatLevel.NONE) return -1;
             if (value == HeatLevel.byIndex(5)) return 0;
+            if (value == HeatLevel.SEETHING) return 2;
             if (value.isAtLeast(HeatLevel.FADING)) return 1;
             return -1;
         });


### PR DESCRIPTION
Heyo! Sorry for the unsolicited PR. This adds an additional config option for hotBurners, which when toggled switches active Charcoal Burners to output the same heat level as Kindled blaze burners and Empowered Charcoal Burners to output the same heat level as Seething blaze burners.  Additionally, it adds an option to configure default fuel burn rate.  The boiler mixin is changed to accommodate burners going up to Seething.

This PR was made for and tested on 1.19.2.