### PR TITLE
Rearrange Low heat level between None and Smouldering

### DIFF
--- a/src/main/java/zeh/createlowheated/content/processing/basicburner/BasicBurnerBlock.java
+++ b/src/main/java/zeh/createlowheated/content/processing/basicburner/BasicBurnerBlock.java
@@ -10,17 +10,12 @@ import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllSoundEvents;
 import com.simibubi.create.Create;
 import com.simibubi.create.content.equipment.wrench.IWrenchable;
-import com.simibubi.create.content.kinetics.belt.behaviour.DirectBeltInputBehaviour;
 import com.simibubi.create.content.kinetics.fan.EncasedFanBlock;
 import com.simibubi.create.content.kinetics.fan.EncasedFanBlockEntity;
-import com.simibubi.create.content.logistics.box.PackageEntity;
 import com.simibubi.create.content.processing.basin.BasinBlockEntity;
 import com.simibubi.create.foundation.block.IBE;
 
-import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
-import com.simibubi.create.foundation.item.ItemHelper;
 import net.createmod.catnip.data.Iterate;
-import net.createmod.catnip.math.VecHelper;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -28,7 +23,6 @@ import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
-import net.minecraft.world.InteractionResult;
 import net.minecraft.world.ItemInteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
@@ -47,9 +41,9 @@ import net.minecraft.world.level.block.state.StateDefinition.Builder;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraft.world.level.pathfinder.PathComputationType;
 import net.minecraft.world.phys.BlockHitResult;
-import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
@@ -60,7 +54,6 @@ import zeh.createlowheated.AllShapes;
 
 import com.simibubi.create.content.processing.burner.BlazeBurnerBlock.HeatLevel;
 import zeh.createlowheated.AllTags;
-import zeh.createlowheated.CreateLowHeated;
 import zeh.createlowheated.common.Configuration;
 
 import net.neoforged.api.distmarker.Dist;
@@ -74,6 +67,7 @@ public class BasicBurnerBlock extends HorizontalDirectionalBlock implements IBE<
     public static final BooleanProperty LIT = BlockStateProperties.LIT;
     public static final BooleanProperty FUELED = BooleanProperty.create("fueled");
     public static final BooleanProperty EMPOWERED = BooleanProperty.create("empowered");
+    public static final IntegerProperty DUNSWE = IntegerProperty.create("dunswe", 0B000000, 0B111111);
     public static final MapCodec<BasicBurnerBlock> CODEC = simpleCodec(BasicBurnerBlock::new);
 
     @Override
@@ -87,12 +81,13 @@ public class BasicBurnerBlock extends HorizontalDirectionalBlock implements IBE<
                 .setValue(HEAT_LEVEL, HeatLevel.NONE)
                 .setValue(LIT, false)
                 .setValue(FUELED, false)
-                .setValue(EMPOWERED, false));
+                .setValue(EMPOWERED, false)
+                .setValue(DUNSWE, 0B000000));
     }
 
     @Override
     protected void createBlockStateDefinition(Builder<Block, BlockState> builder) {
-        builder.add(HEAT_LEVEL, LIT, FUELED, EMPOWERED, FACING);
+        builder.add(HEAT_LEVEL, LIT, FUELED, EMPOWERED, DUNSWE, FACING);
         super.createBlockStateDefinition(builder);
     }
 
@@ -169,10 +164,9 @@ public class BasicBurnerBlock extends HorizontalDirectionalBlock implements IBE<
     @Override
     public BlockState getStateForPlacement(BlockPlaceContext context) {
         boolean isEmpowered = false;
+        int dunswe = 0B000000;
+        BlockPos burnerPos = context.getClickedPos();
         for (Direction side : Iterate.directions) {
-            if (!side.getAxis().isHorizontal()) continue;
-
-            BlockPos burnerPos = context.getClickedPos();
             BlockPos fanPos = burnerPos.relative(side);
             BlockEntity fan = context.getLevel().getBlockEntity(fanPos);
             if (!(fan instanceof EncasedFanBlockEntity fanBE)) continue;
@@ -181,9 +175,15 @@ public class BasicBurnerBlock extends HorizontalDirectionalBlock implements IBE<
             BlockPos fanFacingPos = fanPos.relative(fanFacingDir);
             if (!burnerPos.equals(fanFacingPos)) continue;
 
-            isEmpowered = (Mth.abs(fanBE.getSpeed()) >= Configuration.FAN_SPEED_REQUIRED.get());
+            boolean empowering = (Mth.abs(fanBE.getSpeed()) >= Configuration.FAN_SPEED_REQUIRED.get());
+            if (empowering) {
+                int mask = 0B100000 >> side.ordinal();
+                dunswe = dunswe | mask;
+            }
+            if (Configuration.FAN_HORIZONTAL_ONLY.get() && !side.getAxis().isHorizontal()) continue;
+            if (!isEmpowered) {isEmpowered = true;}
         }
-        return super.getStateForPlacement(context).setValue(EMPOWERED, isEmpowered);
+        return super.getStateForPlacement(context).setValue(EMPOWERED, isEmpowered).setValue(DUNSWE, dunswe);
     }
 
     @Override

--- a/src/main/java/zeh/createlowheated/content/processing/basicburner/BasicBurnerBlockEntity.java
+++ b/src/main/java/zeh/createlowheated/content/processing/basicburner/BasicBurnerBlockEntity.java
@@ -14,6 +14,7 @@ import com.simibubi.create.foundation.utility.CreateLang;
 import net.createmod.catnip.math.VecHelper;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
@@ -83,9 +84,15 @@ public class BasicBurnerBlockEntity extends SmartBlockEntity implements IHaveGog
         return hotBurners;
     }
 
-    public void setEmpowered(boolean value) {
-        if (getEmpoweredFromBlock() == value) return;
-        level.setBlockAndUpdate(worldPosition, getBlockState().setValue(BasicBurnerBlock.EMPOWERED, value));
+    public void setEmpowered(boolean value, Direction direction) {
+        int dunswe = this.getBlockState().getValue(BasicBurnerBlock.DUNSWE);
+        int mask = 0B100000 >> direction.ordinal();
+        if (value) {dunswe = dunswe | mask;}
+        else {dunswe = dunswe & (~mask);}
+        boolean empowered = (dunswe != 0);
+        if (Configuration.FAN_HORIZONTAL_ONLY.get()) {empowered = ((dunswe & 0B001111) != 0);}
+        level.setBlockAndUpdate(worldPosition, getBlockState().setValue(BasicBurnerBlock.EMPOWERED, empowered));
+        level.setBlockAndUpdate(worldPosition, getBlockState().setValue(BasicBurnerBlock.DUNSWE, dunswe));
         notifyUpdate();
     }
 

--- a/src/main/java/zeh/createlowheated/mixin/BlazeBurnerBlockMixin.java
+++ b/src/main/java/zeh/createlowheated/mixin/BlazeBurnerBlockMixin.java
@@ -1,0 +1,19 @@
+package zeh.createlowheated.mixin;
+
+import com.simibubi.create.content.processing.burner.BlazeBurnerBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = BlazeBurnerBlock.class, remap = false)
+public class BlazeBurnerBlockMixin {
+    @Inject(method = "getLight", at = @At("RETURN"), cancellable = true)
+    private static void getLightLowHeated(BlockState state, CallbackInfoReturnable<Integer> cir) {
+        BlazeBurnerBlock.HeatLevel level = state.getValue(BlazeBurnerBlock.HEAT_LEVEL);
+        if (level.name().equals("LOW")) {
+            cir.setReturnValue(8);
+        }
+    }
+}

--- a/src/main/java/zeh/createlowheated/mixin/BlazeBurnerVisualMixin.java
+++ b/src/main/java/zeh/createlowheated/mixin/BlazeBurnerVisualMixin.java
@@ -1,0 +1,49 @@
+package zeh.createlowheated.mixin;
+
+import com.simibubi.create.content.processing.burner.BlazeBurnerBlock;
+import com.simibubi.create.content.processing.burner.BlazeBurnerVisual;
+import com.simibubi.create.content.processing.burner.ScrollInstance;
+import net.createmod.catnip.render.SpriteShiftEntry;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import javax.annotation.Nullable;
+import java.util.Locale;
+
+@Mixin(value = BlazeBurnerVisual.class, remap = false)
+public abstract class BlazeBurnerVisualMixin {
+
+    @Shadow
+    @Nullable
+    private ScrollInstance flame;
+
+    @Shadow
+    private BlazeBurnerBlock.HeatLevel heatLevel;
+
+    @Inject(
+            method = {"setupFlameInstance"},
+            at = @At(value = "INVOKE_ASSIGN", target = "Lcom/simibubi/create/content/processing/burner/BlazeBurnerBlock$HeatLevel;ordinal()I"),
+            locals = LocalCapture.CAPTURE_FAILHARD,
+            cancellable = true
+    )
+    //Smouldering doesn't have a flame ring animation so this doesn't matter a lot
+    public void setupFlameInstanceMixin(CallbackInfo ci, SpriteShiftEntry spriteShift, float spriteWidth, float spriteHeight) {
+        if (heatLevel.getSerializedName().equals("LOW".toLowerCase(Locale.ROOT))) {
+            float speed = 1 / 32f + 1 / 64f * BlazeBurnerBlock.HeatLevel.SMOULDERING.ordinal();
+            flame.speedU = speed / 2;
+            flame.speedV = speed;
+
+            flame.scaleU = spriteWidth / 2;
+            flame.scaleV = spriteHeight / 2;
+
+            flame.diffU = spriteShift.getTarget().getU0() - spriteShift.getOriginal().getU0();
+            flame.diffV = spriteShift.getTarget().getV0() - spriteShift.getOriginal().getV0();
+
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/zeh/createlowheated/mixin/EncasedFanBlockEntityMixin.java
+++ b/src/main/java/zeh/createlowheated/mixin/EncasedFanBlockEntityMixin.java
@@ -29,12 +29,11 @@ public abstract class EncasedFanBlockEntityMixin extends KineticBlockEntity {
     @Unique
     public void createLowHeated$updateBasicBurner(boolean rm) {
         Direction fanFacingDir = getAirflowOriginSide();
-        if (Configuration.FAN_HORIZONTAL_ONLY.get()) if (!fanFacingDir.getAxis().isHorizontal()) return;
 
         BlockEntity poweredBurner = level.getBlockEntity(worldPosition.relative(fanFacingDir));
         if (!(poweredBurner instanceof BasicBurnerBlockEntity burnerBE))  return;
 
-        burnerBE.setEmpowered(!rm && (Mth.abs(getSpeed()) >= Configuration.FAN_SPEED_REQUIRED.get()));
+        burnerBE.setEmpowered(!rm && (Mth.abs(getSpeed()) >= Configuration.FAN_SPEED_REQUIRED.get()), fanFacingDir.getOpposite());
     }
 
     @Inject(method = "onSpeedChanged", at = @At("HEAD"))

--- a/src/main/java/zeh/createlowheated/mixin/HeatLevelMixin.java
+++ b/src/main/java/zeh/createlowheated/mixin/HeatLevelMixin.java
@@ -6,9 +6,13 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.gen.Invoker;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Locale;
 
 @Mixin(value = HeatLevel.class, remap = false)
 public abstract class HeatLevelMixin {
@@ -31,5 +35,53 @@ public abstract class HeatLevelMixin {
         HeatLevelMixin.$VALUES = variants.toArray(new HeatLevel[0]);
         return heat;
     }
+
+    //Since only nextActiveLevel used this no mixin is used
+    /*
+    @Inject(method = "byIndex", at = @At("RETURN"))
+    private static void byIndex(int index, CallbackInfoReturnable<HeatLevel> cir) {
+    }
+     */
+
+    @Inject(method = "nextActiveLevel", at = @At("RETURN"), cancellable = true)
+    public void nextActiveLevel(CallbackInfoReturnable<HeatLevel> cir) {
+        if (this.getSerializedName().equals("NONE".toLowerCase(Locale.ROOT))) {
+            cir.setReturnValue(HeatLevelMixin.LOW);
+            return;
+        }
+        if (this.getSerializedName().equals("LOW".toLowerCase(Locale.ROOT))) {
+            cir.setReturnValue(HeatLevel.SMOULDERING);
+            return;
+        }
+        if (this.getSerializedName().equals("SEETHING".toLowerCase(Locale.ROOT))) {
+            cir.setReturnValue(HeatLevelMixin.LOW); //Next ACTIVE HeatLevel
+        }
+    }
+
+    @Inject(method = "isAtLeast", at = @At("RETURN"), cancellable = true)
+    public void isAtLeast(HeatLevel heatLevel, CallbackInfoReturnable<Boolean> cir) {
+        if (heatLevel.equals(HeatLevel.NONE)) {
+            cir.setReturnValue(true);
+            return;
+        }
+        if (heatLevel.equals(HeatLevelMixin.LOW)) {
+            if (this.equals(HeatLevel.NONE)) {
+                cir.setReturnValue(false);
+            } else {
+                cir.setReturnValue(true);
+            }
+            return;
+        }
+        if (this.equals(HeatLevelMixin.LOW)) {
+            if (heatLevel.equals(HeatLevelMixin.LOW /*|| heatLevel.equals(HeatLevel.NONE)*/ )) {
+                cir.setReturnValue(true);
+            } else {
+                cir.setReturnValue(false);
+            }
+        }
+    }
+
+    @Shadow
+    public abstract String getSerializedName();
 
 }

--- a/src/main/resources/createlowheated.mixins.json
+++ b/src/main/resources/createlowheated.mixins.json
@@ -1,21 +1,23 @@
 {
-	"required": true,
-	"minVersion": "0.8",
-	"priority": 2000,
-	"package": "zeh.createlowheated.mixin",
-	"compatibilityLevel": "JAVA_17",
-	"mixins": [
-		"BasinBlockEntityMixin",
-		"BoilerHeatersMixin",
-		"HeatConditionMixin",
-		"HeatLevelMixin",
-		"EncasedFanBlockEntityMixin",
-		"BasinCategoryMixin",
-		"MixingCategoryMixin",
-        "CreateAdditionMixin",
-		"DispenserBlockMixin"
-	],
-	"injectors": {
-		"defaultRequire": 1
+  "required": true,
+  "minVersion": "0.8",
+  "priority": 2000,
+  "package": "zeh.createlowheated.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "mixins": [
+    "BasinBlockEntityMixin",
+    "BasinCategoryMixin",
+    "BlazeBurnerBlockMixin",
+    "BlazeBurnerVisualMixin",
+    "BoilerHeatersMixin",
+    "CreateAdditionMixin",
+    "DispenserBlockMixin",
+    "EncasedFanBlockEntityMixin",
+    "HeatConditionMixin",
+    "HeatLevelMixin",
+    "MixingCategoryMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
 	}
 }


### PR DESCRIPTION
I was working on a WoodenCog fork and find some inconsistencies when trying to map heat levels to TerraFirmaCraft temperatures, more specifically, Low heat level from CreateLowHeated has ordinal higher that heat levels from Create itself, resulting unexpected return of method nextActiveLevel and isAtLeast. To fix this issue, I did some extra mixins to rearrage heat levels by changing return values of these methods.

Summary:
·Mixin methods in BlazeBurnerBlock.HeatLevel to rearrange Low heat level between None and Smouldering.
·Light level of Blaze Burners at Low heat level are now consistent with Smouldering ones.